### PR TITLE
Fix application root directory problem.

### DIFF
--- a/src/Spryker/Zed/Router/Business/Router/RouterResource/RouterResource.php
+++ b/src/Spryker/Zed/Router/Business/Router/RouterResource/RouterResource.php
@@ -131,7 +131,7 @@ class RouterResource implements ResourceInterface
     protected function getClassNameFromFile(SplFileInfo $fileInfo): string
     {
         $classNameParts = explode(DIRECTORY_SEPARATOR, $fileInfo->getPathname());
-        $srcPosition = array_search('src', $classNameParts);
+        $srcPosition = array_search('src', array_reverse($classNameParts, true), true);
         $className = implode('\\', array_slice($classNameParts, $srcPosition + 1));
         $className = str_replace(['.php', '\\\\'], ['', '\\'], $className);
 


### PR DESCRIPTION
## Problem description:

Current `RouterResource::getClassNameFromFile()` yields incorrect FQCNs whenever a project is located under multiple `src/` directories, e.g. `/home/user/project/src/src/Pyz/Zed/SomeModule/Communication/SomeController.php` yields  `src\Pyz\Zed\SomeModule\Communication\SomeController` which is not a valid FQCN and causes class autoloading error.

## Proposed solution:

`RouterResource::getClassNameFromFile()` should use the index of last `src` in `$classNameParts`.