### PR TITLE
Patch 1

### DIFF
--- a/src/Spryker/Zed/Router/Communication/Plugin/EventDispatcher/RequestAttributesEventDispatcherPlugin.php
+++ b/src/Spryker/Zed/Router/Communication/Plugin/EventDispatcher/RequestAttributesEventDispatcherPlugin.php
@@ -187,7 +187,7 @@ class RequestAttributesEventDispatcherPlugin extends AbstractPlugin implements E
      */
     protected function getModule(Request $request, array $requestUriFragments): string
     {
-        if (count($requestUriFragments) < 1) {
+        if ($this->isDefaultModule($requestUriFragments)) {
             return static::DEFAULT_MODULE;
         }
 
@@ -249,5 +249,19 @@ class RequestAttributesEventDispatcherPlugin extends AbstractPlugin implements E
                 throw new InvalidArgumentException(sprintf('Required parameter --%s is missing!', $parameter));
             }
         }
+    }
+    
+    /**
+     * @param array $requestUriFragments
+     *
+     * @return bool
+     */
+    protected function isDefaultModule(array $requestUriFragments): bool
+    {
+        return count($requestUriFragments) < 1 ||
+        (
+            isset($requestUriFragments[static::POSITION_OF_MODULE])
+            && $requestUriFragments[static::POSITION_OF_MODULE] === ''
+        );
     }
 }

--- a/tests/SprykerTest/Zed/Router/Communication/Plugin/EventDispatcher/RequestAttributeEventDispatcherPluginTest.php
+++ b/tests/SprykerTest/Zed/Router/Communication/Plugin/EventDispatcher/RequestAttributeEventDispatcherPluginTest.php
@@ -109,6 +109,7 @@ class RequestAttributeEventDispatcherPluginTest extends Unit
     public function urlStack(): array
     {
         return [
+            ['/', 'application', 'index', 'index'],
             ['/foo', 'foo', 'index', 'index'],
             ['/foo/bar', 'foo', 'bar', 'index'],
             ['/foo/bar/baz', 'foo', 'bar', 'baz'],


### PR DESCRIPTION
## PR Description

When `requestUriFragments` is exploded, on the `/` endpoint, it returns an array with one index and empty string (`['']`, https://3v4l.org/FO5Kj), and, therefore the original condition will never be met (`count($requestUriFragments) < 1`), and therefore the default module (application) is not set.

To keep possible BC i've maintained the original condition and added another one.

Also a test case were added to check if the condition is met in the case of the default module.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
